### PR TITLE
Run the data extraction pipeline in k8s

### DIFF
--- a/run_spark_data_process.sh
+++ b/run_spark_data_process.sh
@@ -19,6 +19,7 @@ pushd $SPARK_HOME
  --class com.holdenkarau.predict.pr.comments.sparkProject.DataFetchSCApp \
  --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark3 \
  --conf spark.kubernetes.namespace=spark \
+ --conf spark.kubernetes.executor.memoryOverhead=2500 \
  $JAR \
  $INPUT $OUTPUT $CACHE
 popd

--- a/run_spark_data_process.sh
+++ b/run_spark_data_process.sh
@@ -9,9 +9,11 @@ export OUTPUT=${OUTPUT:="gs://frank-the-unicorn/dev/output"}
 export CACHE=${CACHE:="gs://frank-the-unicorn/dev/cache"}
 export JAR=${JAR:="gs://frank-the-unicorn/jars/$COMMIT.jar"}
 export NUM_EXECS=${NUM_EXECS:="3"}
-export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="24g"}
+export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="21g"}
 export SPARK_DEFAULT_PARALLELISM=${SPARK_DEFAULT_PARALLELISM:="5000"}
-export APP_NAME=${APP_NAME:="spark-data-fetcher"} + `date`
+export APP_NAME=${APP_NAME:="spark-data-fetcher"}
+export RUNDATE=$(date +"%T")
+export APP_NAME="$APP_NAME-$RUNDATE"
 pushd $SPARK_HOME
 ./bin/spark-submit --master k8s://http://127.0.0.1:8001  \
   --deploy-mode cluster --conf \

--- a/run_spark_data_process.sh
+++ b/run_spark_data_process.sh
@@ -10,6 +10,7 @@ export CACHE=${CACHE:="gs://frank-the-unicorn/dev/cache"}
 export JAR=${JAR:="gs://frank-the-unicorn/jars/$COMMIT.jar"}
 export NUM_EXECS=${NUM_EXECS:="3"}
 export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="24g"}
+export SPARK_DEFAULT_PARALLELISM=${SPARK_DEFAULT_PARALLELISM:="5000"}
 pushd $SPARK_HOME
 ./bin/spark-submit --master k8s://http://127.0.0.1:8001  \
   --deploy-mode cluster --conf \
@@ -19,7 +20,8 @@ pushd $SPARK_HOME
  --class com.holdenkarau.predict.pr.comments.sparkProject.DataFetchSCApp \
  --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark3 \
  --conf spark.kubernetes.namespace=spark \
- --conf spark.kubernetes.executor.memoryOverhead=2500 \
+ --conf spark.kubernetes.executor.memoryOverhead=3000 \
+ --conf spark.default.parallelism=$SPARK_DEFAULT_PARALLELISM
  $JAR \
  $INPUT $OUTPUT $CACHE
 popd

--- a/run_spark_data_process.sh
+++ b/run_spark_data_process.sh
@@ -11,6 +11,7 @@ export JAR=${JAR:="gs://frank-the-unicorn/jars/$COMMIT.jar"}
 export NUM_EXECS=${NUM_EXECS:="3"}
 export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="24g"}
 export SPARK_DEFAULT_PARALLELISM=${SPARK_DEFAULT_PARALLELISM:="5000"}
+export APP_NAME=${APP_NAME:="spark-data-fetcher"} + `date`
 pushd $SPARK_HOME
 ./bin/spark-submit --master k8s://http://127.0.0.1:8001  \
   --deploy-mode cluster --conf \
@@ -21,7 +22,8 @@ pushd $SPARK_HOME
  --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark3 \
  --conf spark.kubernetes.namespace=spark \
  --conf spark.kubernetes.executor.memoryOverhead=3000 \
- --conf spark.default.parallelism=$SPARK_DEFAULT_PARALLELISM
+ --conf spark.default.parallelism=$SPARK_DEFAULT_PARALLELISM \
+ --conf spark.app.name=$APP_NAME \
  $JAR \
  $INPUT $OUTPUT $CACHE
 popd

--- a/run_spark_data_process.sh
+++ b/run_spark_data_process.sh
@@ -9,7 +9,7 @@ export OUTPUT=${OUTPUT:="gs://frank-the-unicorn/dev_output"}
 export CACHE=${CACHE:="gs://frank-the-unicorn/cache"}
 export JAR=${JAR:="gs://frank-the-unicorn/jars/$COMMIT.jar"}
 export NUM_EXECS=${NUM_EXECS:="3"}
-export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="8g"}
+export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="16g"}
 pushd $SPARK_HOME
 ./bin/spark-submit --master k8s://http://127.0.0.1:8001  \
   --deploy-mode cluster --conf \

--- a/run_spark_data_process.sh
+++ b/run_spark_data_process.sh
@@ -15,7 +15,7 @@ pushd $SPARK_HOME
   --deploy-mode cluster --conf \
  spark.kubernetes.container.image=$DOCKER_REPO/spark:$SPARK_VERSION \
  --conf spark.executor.instances=$NUM_EXECS \
- --conf spark.executor.memory=$SPARK_EXEC_MEMORY
+ --conf spark.executor.memory=$SPARK_EXEC_MEMORY \
  --class com.holdenkarau.predict.pr.comments.sparkProject.DataFetchSCApp \
  --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark3 \
  --conf spark.kubernetes.namespace=spark \

--- a/run_spark_data_process.sh
+++ b/run_spark_data_process.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+set -x
+export COMMIT=$(git rev-parse HEAD)
+export DOCKER_REPO=${DOCKER_REPO:="gcr.io/boos-demo-projects-are-rad/spark-prod"}
+export SPARK_VERSION=${SPARK_VERSION:="v2.4.0-with-deps"}
+export INPUT=${INPUT:="gs://tigeys-buckets-are-rad/20190118.csv"}
+export OUTPUT=${OUTPUT:="gs://frank-the-unicorn/dev_output"}
+export CACHE=${CACHE:="gs://frank-the-unicorn/cache"}
+export JAR=${JAR:="gs://frank-the-unicorn/jars/$COMMIT.jar"}
+pushd $SPARK_HOME
+./bin/spark-submit --master k8s://http://127.0.0.1:8001  \
+  --deploy-mode cluster --conf \
+ spark.kubernetes.container.image=$DOCKER_REPO/spark:$SPARK_VERSION \
+ --conf spark.executor.instances=3 \
+ --class com.holdenkarau.predict.pr.comments.sparkProject.DataFetchSCApp \
+ --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark3 \
+ --conf spark.kubernetes.namespace=spark \
+ $JAR \
+ $INPUT $OUTPUT $CACHE
+popd

--- a/run_spark_data_process.sh
+++ b/run_spark_data_process.sh
@@ -5,11 +5,11 @@ export COMMIT=$(git rev-parse HEAD)
 export DOCKER_REPO=${DOCKER_REPO:="gcr.io/boos-demo-projects-are-rad/spark-prod"}
 export SPARK_VERSION=${SPARK_VERSION:="v2.4.0-with-deps"}
 export INPUT=${INPUT:="gs://tigeys-buckets-are-rad/20190118.csv"}
-export OUTPUT=${OUTPUT:="gs://frank-the-unicorn/dev_output"}
-export CACHE=${CACHE:="gs://frank-the-unicorn/cache"}
+export OUTPUT=${OUTPUT:="gs://frank-the-unicorn/dev/output"}
+export CACHE=${CACHE:="gs://frank-the-unicorn/dev/cache"}
 export JAR=${JAR:="gs://frank-the-unicorn/jars/$COMMIT.jar"}
 export NUM_EXECS=${NUM_EXECS:="3"}
-export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="14g"}
+export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="24g"}
 pushd $SPARK_HOME
 ./bin/spark-submit --master k8s://http://127.0.0.1:8001  \
   --deploy-mode cluster --conf \

--- a/run_spark_data_process.sh
+++ b/run_spark_data_process.sh
@@ -8,11 +8,14 @@ export INPUT=${INPUT:="gs://tigeys-buckets-are-rad/20190118.csv"}
 export OUTPUT=${OUTPUT:="gs://frank-the-unicorn/dev_output"}
 export CACHE=${CACHE:="gs://frank-the-unicorn/cache"}
 export JAR=${JAR:="gs://frank-the-unicorn/jars/$COMMIT.jar"}
+export NUM_EXECS=${NUM_EXECS:="3"}
+export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="8g"}
 pushd $SPARK_HOME
 ./bin/spark-submit --master k8s://http://127.0.0.1:8001  \
   --deploy-mode cluster --conf \
  spark.kubernetes.container.image=$DOCKER_REPO/spark:$SPARK_VERSION \
- --conf spark.executor.instances=3 \
+ --conf spark.executor.instances=$NUM_EXECS \
+ --conf spark.executor.memory=$SPARK_EXEC_MEMORY
  --class com.holdenkarau.predict.pr.comments.sparkProject.DataFetchSCApp \
  --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark3 \
  --conf spark.kubernetes.namespace=spark \

--- a/run_spark_data_process.sh
+++ b/run_spark_data_process.sh
@@ -9,7 +9,7 @@ export OUTPUT=${OUTPUT:="gs://frank-the-unicorn/dev_output"}
 export CACHE=${CACHE:="gs://frank-the-unicorn/cache"}
 export JAR=${JAR:="gs://frank-the-unicorn/jars/$COMMIT.jar"}
 export NUM_EXECS=${NUM_EXECS:="3"}
-export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="16g"}
+export SPARK_EXEC_MEMORY=${SPARK_EXEC_MEMORY:="14g"}
 pushd $SPARK_HOME
 ./bin/spark-submit --master k8s://http://127.0.0.1:8001  \
   --deploy-mode cluster --conf \

--- a/runme.sh
+++ b/runme.sh
@@ -1,0 +1,6 @@
+set -e
+set -x
+#APP_NAME=dev SPARK_DEFAULT_PARALLELISM=100 NUM_EXECS=10 ./run_spark_data_process.sh
+#APP_NAME=year2019 SPARK_DEFAULT_PARALLELISM=200 NUM_EXECS=15 INPUT="gs://tigeys-buckets-are-rad/2019*.csv" OUTPUT="gs://frank-the-unicorn/2019/output" CACHE=gs://frank-the-unicorn/2019/cache ./run_spark_data_process.sh
+#APP_NAME=year2018 SPARK_DEFAULT_PARALLELISM=1000 NUM_EXECS=20 INPUT="gs://tigeys-buckets-are-rad/2018*.csv" OUTPUT="gs://frank-the-unicorn/2018/output" CACHE=gs://frank-the-unicorn/2018/cache ./run_spark_data_process.sh
+APP_NAME=full  SPARK_DEFAULT_PARALLELISM=3000 NUM_EXECS=30 INPUT="gs://tigeys-buckets-are-rad/*.csv" OUTPUT="gs://frank-the-unicorn/full/output" CACHE=gs://frank-the-unicorn/full/cache ./run_spark_data_process.sh

--- a/sparkproject/src/main/scala/com/holdenkarau/predict/pr/comments/dataprep/BufferedFutureIterator.scala
+++ b/sparkproject/src/main/scala/com/holdenkarau/predict/pr/comments/dataprep/BufferedFutureIterator.scala
@@ -50,6 +50,7 @@ class BufferedFutureIterator[T](
         future onComplete completeFun
       } catch {
         case e: java.util.NoSuchElementException => None
+        case _ => None // inet, etc.
       }
     }
   }
@@ -72,7 +73,12 @@ class BufferedFutureIterator[T](
           }
         }
       }
-    Await.result(resultOpt.get, Duration.Inf)
+      // Ignore any problems during waiting
+      try {
+        Await.result(resultOpt.get, Duration.Inf)
+      } catch {
+        case _ => None
+      }
     } else {
       throw new java.util.NoSuchElementException("Out of elements")
     }

--- a/sparkproject/src/main/scala/com/holdenkarau/predict/pr/comments/dataprep/DataFetch.scala
+++ b/sparkproject/src/main/scala/com/holdenkarau/predict/pr/comments/dataprep/DataFetch.scala
@@ -85,7 +85,7 @@ class DataFetch(sc: SparkContext) {
   }
 
   def loadInput(input: String) = {
-    createCSVReader().load(input).repartition(1000)
+    createCSVReader().load(input).repartition(10000)
   }
 
   def loadInput(input: Dataset[String]) = {

--- a/sparkproject/src/main/scala/com/holdenkarau/predict/pr/comments/dataprep/DataFetch.scala
+++ b/sparkproject/src/main/scala/com/holdenkarau/predict/pr/comments/dataprep/DataFetch.scala
@@ -85,7 +85,10 @@ class DataFetch(sc: SparkContext) {
   }
 
   def loadInput(input: String) = {
-    createCSVReader().load(input).repartition(10000)
+    // Use default parallelism for the input because the other values
+    // do it based on the input layout and our input is not well partitioned.
+    val inputParallelism = sc.getConf.get("spark.default.parallelism", "100").toInt
+    createCSVReader().load(input).repartition(inputParallelism)
   }
 
   def loadInput(input: Dataset[String]) = {

--- a/sparkproject/src/main/scala/com/holdenkarau/predict/pr/comments/dataprep/DataFetch.scala
+++ b/sparkproject/src/main/scala/com/holdenkarau/predict/pr/comments/dataprep/DataFetch.scala
@@ -166,7 +166,8 @@ object DataFetch {
       Iterator[(ParsedInputData, StoredPatch)] = {
     val patchFutures = records.map(fetchPatch)
     val resultFutures = patchFutures.map(future => future.map(processResponse))
-    val result = new BufferedFutureIterator(resultFutures).flatMap(x => x)
+    val result = new BufferedFutureIterator(resultFutures)
+      .flatMap(x => x).flatMap(x => x)
     result
   }
 

--- a/sparkproject/src/main/scala/com/holdenkarau/predict/pr/comments/dataprep/DataFetch.scala
+++ b/sparkproject/src/main/scala/com/holdenkarau/predict/pr/comments/dataprep/DataFetch.scala
@@ -85,7 +85,7 @@ class DataFetch(sc: SparkContext) {
   }
 
   def loadInput(input: String) = {
-    createCSVReader().load(input)
+    createCSVReader().load(input).repartition(1000)
   }
 
   def loadInput(input: Dataset[String]) = {

--- a/sparkproject/src/test/scala/com/holdenkarau/predict/pr/comments/dataprep/BufferedFutureIteratorTest.scala
+++ b/sparkproject/src/test/scala/com/holdenkarau/predict/pr/comments/dataprep/BufferedFutureIteratorTest.scala
@@ -42,7 +42,7 @@ object BufferedFutureIteratorTest {
     val futureIterators = iterators.map(itr => itr.map(Future.successful(_)))
     val bufferedIterators = futureIterators.map(
       new BufferedFutureIterator(_, bufferSize=bufferSize))
-    val results = bufferedIterators.map(_.toList)
+    val results = bufferedIterators.map(_.flatMap(x => x).toList)
     val compare = inputs.zip(results)
     compare.foreach{case (origin, result) =>
       origin should contain theSameElementsAs result}
@@ -60,7 +60,7 @@ object BufferedFutureIteratorTest {
     }
     val bufferedIterator = new BufferedFutureIterator(futureIterator,
       bufferSize=bufferSize)
-    val results = bufferedIterator.toList
+    val results = bufferedIterator.flatMap(x => x).toList
     val original = inputs.map(_._1)
     original should contain theSameElementsAs results
   }

--- a/upload_spark_jar.sh
+++ b/upload_spark_jar.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+set -x
+export COMMIT=$(git rev-parse HEAD)
+pushd sparkproject/
+sbt assembly
+gsutil cp ./target/scala-2.11/sparkProject-assembly-0.0.1.jar gs://frank-the-unicorn/jars/$COMMIT.jar
+popd
+echo $COMMIT


### PR DESCRIPTION
Fix up some problems with the data extraction pipeline when running at scale namely:
1) Hopefully reduce future capture overhead in bufferediterator
2) Drop out the partially null records which randomly show up as early as possible
3) Some of the GH URIs are malformed, drop those
4) Some of the GH URIs don't resolve, drop those
5) Don't depend on input parallelism to be reasonable (it's not with our data layout), explicitly repartition
6) Bump the default parallelism so that partitions aren't making things sad
Also add some helper scripts:
1) Build & upload JAR so we can run it
2) Script to run data extraction pipeline with reasonable-ish defaults
Known issues introduced:
1) Buffered Iterator hasNext is potentially optimistic, our use case should be fine but if not we can update next a bit
